### PR TITLE
179 fix broken footer image

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,18 +5,18 @@
       </p>
       <ul class="mdl-mini-footer__link-list">
         <li><a href="https://github.com/100Automations">
-          <img src='assets/images/icons/footer-icons/github-logo.png'></a></li>
+          <img src='{% link assets/images/icons/footer-icons/github-logo.png %}'></a></li>
         <li><a href="https://www.youtube.com/channel/UCS_BOwZ5Hj3pGHN0gmx4gAA?guided_help_flow=5">
-          <img src='assets/images/icons/footer-icons/youtube-logo.png'></a></li>
+          <img src='{% link assets/images/icons/footer-icons/youtube-logo.png %}'></a></li>
         <li><a href="https://www.instagram.com/100automations/">
-          <img src='assets/images/icons/footer-icons/instagram-logo.png'></a></li>
+          <img src='{% link assets/images/icons/footer-icons/instagram-logo.png %}'></a></li>
         <li><a href="https://twitter.com/100automations">
-          <img src='assets/images/icons/footer-icons/twitter-logo.png'></a></li>
+          <img src='{% link assets/images/icons/footer-icons/twitter-logo.png %}'></a></li>
         <li><a href="https://www.facebook.com/100Automations">
-          <img src='assets/images/icons/footer-icons/facebook-logo.png'></a></li>
+          <img src='{% link assets/images/icons/footer-icons/facebook-logo.png %}'></a></li>
       </ul>
   </div>
   <div class="footer-logo">
-      <img src='assets/images/icons/footer-icons/hackforla-logo.png'>
+      <img src='{% link assets/images/icons/footer-icons/hackforla-logo.png %}'>
   </div>
 </footer>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   website:
     image: jekyll/jekyll:pages
     container_name: website
-    command: jekyll serve --force_polling --livereload --config _config.yml,_config.docker.yml
+    command: jekyll serve --force_polling --livereload --config _config.yml,_config.docker.yml -I
     environment:
       - JEKYLL_ENV=docker
     ports:


### PR DESCRIPTION
Fix #179 .

Footer logos are now rendering correctly. It should now also be rendering correctly within any future pages and components.

![image](https://user-images.githubusercontent.com/32349001/109854420-0685d380-7c25-11eb-94fa-634485dc0a9d.png)
