### PR TITLE
Replace footer url to be inside within liquid link tags

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,18 +5,18 @@
       </p>
       <ul class="mdl-mini-footer__link-list">
         <li><a href="https://github.com/100Automations">
-          <img src='assets/images/icons/footer-icons/github-logo.png'></a></li>
+          <img src='{% link assets/images/icons/footer-icons/github-logo.png %}'></a></li>
         <li><a href="https://www.youtube.com/channel/UCS_BOwZ5Hj3pGHN0gmx4gAA?guided_help_flow=5">
-          <img src='assets/images/icons/footer-icons/youtube-logo.png'></a></li>
+          <img src='{% link assets/images/icons/footer-icons/youtube-logo.png %}'></a></li>
         <li><a href="https://www.instagram.com/100automations/">
-          <img src='assets/images/icons/footer-icons/instagram-logo.png'></a></li>
+          <img src='{% link assets/images/icons/footer-icons/instagram-logo.png %}'></a></li>
         <li><a href="https://twitter.com/100automations">
-          <img src='assets/images/icons/footer-icons/twitter-logo.png'></a></li>
+          <img src='{% link assets/images/icons/footer-icons/twitter-logo.png %}'></a></li>
         <li><a href="https://www.facebook.com/100Automations">
-          <img src='assets/images/icons/footer-icons/facebook-logo.png'></a></li>
+          <img src='{% link assets/images/icons/footer-icons/facebook-logo.png %}'></a></li>
       </ul>
   </div>
   <div class="footer-logo">
-      <img src='assets/images/icons/footer-icons/hackforla-logo.png'>
+      <img src='{%link assets/images/icons/footer-icons/hackforla-logo.png%}'>
   </div>
 </footer>


### PR DESCRIPTION
Fix #179 

- [x] Modify the links to use liquid link tag such that build will fail, if paths are wrong.

![image](https://user-images.githubusercontent.com/32349001/109855702-9bd59780-7c26-11eb-9ec2-fbfe3689a532.png)
