### PR TITLE
inline styles were not necessary here.

### DIFF
--- a/_includes/ato_grid.html
+++ b/_includes/ato_grid.html
@@ -31,8 +31,8 @@
           <!-- Automation Readme url is located in links index 1 -->
           <!-- We will need to design a README.md button -->
           <a href="{{ automation.links[1].url }}"
-            class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect" style="font-family: Poppins">
-            ReadMe <i class="fa fa-github" style="color:white"></i>
+            class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
+            ReadMe <i class="fa fa-github"></i>
           </a>
         </div>
       </div>


### PR DESCRIPTION
Css specificity in  stylesheet is effective without the inline styles. Inline styles for font-family and color were redundant. 


Fixes #160