### PR TITLE
187 override vscode settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ Gemfile.lock
 
 # Ignore OS and IDE tracking files
 .DS_store
-.vscode
 .idea
 
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    // The default end of line character.
+//  - \n: LF
+//  - \r\n: CRLF
+//  - auto: Uses operating system specific end of line character.
+"files.eol": "\n",
+
+// Format a file on save. A formatter must be available, the file must not be saved after delay, and the 
+// editor must not be shutting down.
+"editor.formatOnSave": false
+}


### PR DESCRIPTION
Fixes #187 

The changes made are
- Update .gitignore file such that the settings.json file within the .vscode folder is not ignored.
- Implement vscode override at workspace level that prevents mass auto formatting of codebase when saving a file
- Also an override to ensure that new lines styles are also consistent across all code basses and contributors.