### PR TITLE
quick fix for guides: spacing issue when screen gets smaller

### DIFF
--- a/_sass/layouts/guides.scss
+++ b/_sass/layouts/guides.scss
@@ -13,10 +13,11 @@ div.guide{
 
 //Bottom Section Element
   section.body-container{
-    grid-column-gap: 22rem;
+    // grid-column-gap: 22rem;
     font-family: 'Open Sans', sans-serif;
     padding-bottom: 5rem;
     display: flex;
+    justify-content: space-between;
 
     .body-container ul{
       list-style-type: disc;
@@ -33,6 +34,7 @@ div.guide{
 //Top Div Element
     div.content-container, div.content-container--guide{
       grid-column: 1/8;
+      width: 51em;
   
       ul ul {
         list-style-type: disc;


### PR DESCRIPTION
Fixes a small issue with spacing between content box and body text. I can also add media queries to the images if need be. Bug is mostly fixed

Before:

![Screenshot from 2021-09-02 15-44-12](https://user-images.githubusercontent.com/54788134/131916095-113c614a-5630-4276-95e9-c8e628e24ff4.png)

After:

![Screenshot from 2021-09-02 16-00-58](https://user-images.githubusercontent.com/54788134/131916131-ae574bd1-7d42-48e4-aab5-7f605612736e.png)
