### PR TITLE
fixed issue #439 about page

### DIFF
--- a/_includes/About/about_one.html
+++ b/_includes/About/about_one.html
@@ -8,7 +8,7 @@
     
         <div class="about_one_text flexbox_row">
            
-                <p>
+                <p class='first-p'>
                     A project that showcases automations and microservices that reduce repetitive work in open source
                     development; a project where anyone can create, collaborate on, and get credit for open source
                     automations that assist the wider Civic Tech community.
@@ -18,7 +18,7 @@
                     <br>
                     The name derives from the project's goal to reach 100 developed automations in our first twelve months.
                 </p>
-                <div class="roadmap flexbox_row">
+                <div class="roadmap">
                     <h3>
                         3/100
                     </h3>

--- a/_sass/includes/About/about_one.scss
+++ b/_sass/includes/About/about_one.scss
@@ -4,32 +4,42 @@ div.about_one{
  div.about_one_title{
     flex-flow: unset;
     flex:1;
-    img, h4{
-    margin: .5em;
+    img{
+    margin: 81.89px 0 35px 47px;
     }
     ;
     h4{
+        margin: 81.89px 0 16px 20.37px;
+        height: 84px;
         color: $white;
         justify-content: left;
         text-align: left;
+        font-size: 60px;
     }
     ;
  }
  ;
  div.about_one_text{ 
-     p{
+
+     .first-p{
+        width: 694px;
         color: $white;
         text-align: left;
-        margin-left: 1em;
+        margin: 0 0 37.5px 7.5rem;
         flex:1;
         }
         ;
         .roadmap{
+            margin-bottom: 9.4rem;
             flex: 1;
             flex-direction: column;
             h3{
-                margin: 0;
+                margin: 0 0 0 215px;
                 color: $white;
+                font-size: 60px;
+            }
+            p{
+                margin: 0 0 0 175px;
             }
         }
  }


### PR DESCRIPTION
#439 fixed spacing with the about page. Spacing on the page was adjusted to look similar to the Figma. The wording in the header is different from the Figma layout so some spacing is not exactly the same. 