### PR TITLE
Update to guides with proper link to automation card template

### DIFF
--- a/_guides/prep-automation-for-publication.md
+++ b/_guides/prep-automation-for-publication.md
@@ -63,5 +63,5 @@ You can list all that apply:
 
 
 ## Ready to submit your automation?
-Use our [issue template](https://github.com/100Automations/Website/issues/new?assignees=&labels=documentation%2C+good+first+issue&template=create-automation-card-for--automation-name-.md&title=Create+automation+card+for+%5Bautomation+name%5D){:target="_blank"} for submitting the information we will need for the project card to appear on the [100automations.org](https://100automations.org) website
+Use our [issue template](https://github.com/100Automations/futureautomations/issues/new?assignees=&labels=documentation%2C+good+first+issue&template=create-automation-card-for--automation-name-.md&title=Create+automation+card+for+%5Bautomation+name%5D){:target="_blank"} for submitting the information we will need for the project card to appear on the [100automations.org](https://100automations.org) website
 

--- a/_guides/start_building.md
+++ b/_guides/start_building.md
@@ -21,7 +21,7 @@ Ensure the repository contains, at a minimum:
 - A Contributing.md
 
 ### 3. Automation Card Template
-Once the repository is complete with documentation and the automation code, complete [this automation card template](https://github.com/100Automations/futureautomations/issues/new?assignees=&labels=documentation%2C+review&template=-automation-proposal.md&title=%5BAutomation+Name%5D+Proposal) in the Future Automations repo and move it to the [Review column](https://github.com/100Automations/futureautomations/projects/1#column-9876980)
+Once the repository is complete with documentation and the automation code, complete [this automation card template](https://github.com/100Automations/futureautomations/issues/new?assignees=&labels=documentation%2C+good+first+issue&template=create-automation-card-for--automation-name-.md&title=Create+automation+card+for+%5Bautomation+name%5D) in the Future Automations repo and move it to the [Review column](https://github.com/100Automations/futureautomations/projects/1#column-9876980)
 
 If you prefer completing the automation card template over multiple sessions, place it in the [In Progress column](https://github.com/100Automations/futureautomations/projects/1#column-9876974) on the Future Automations board
 


### PR DESCRIPTION
Replaced the url for submitting a new project card to the future automations repo with the actual template instead of a blank template